### PR TITLE
[Patch] Fix dismissal bug

### DIFF
--- a/Sources/SwiftfulRouting/Core/RouterView.swift
+++ b/Sources/SwiftfulRouting/Core/RouterView.swift
@@ -176,7 +176,7 @@ public struct RouterView<T:View>: View, Router {
         // This is called when isPresented changes, and should only removeLast if isPresented = false
         
         if !isPresented && screenStack.count == (screenStackCount + 1) {
-            screenStack.removeLast()
+//            screenStack.removeLast()
         }
     }
     

--- a/Sources/SwiftfulRouting/Core/RouterView.swift
+++ b/Sources/SwiftfulRouting/Core/RouterView.swift
@@ -77,7 +77,6 @@ public struct RouterView<T:View>: View, Router {
                     sheetSelection: sheetSelection,
                     sheetSelectionEnabled: sheetSelectionEnabled,
                     showDragIndicator: showDragIndicator)
-                .onChangeIfiOS15(of: presentationMode.wrappedValue.isPresented, perform: dropLastScreenFromStackForiOS16IfNeeded)
         }
         .showingAlert(option: alertOption, item: $alert)
         .showingModal(configuration: modalConfiguration, item: $modal)
@@ -166,18 +165,6 @@ public struct RouterView<T:View>: View, Router {
     public func popToRoot() {
         self.screens = []
         self.screenStack = []
-    }
-    
-    private func dropLastScreenFromStackForiOS16IfNeeded(isPresented: Bool) {
-        // iOS 16 supports screenStack, however,
-        // if user dismisses the screen using .dismissScreen or environment modes, then the screen will dismiss without removing last item from screenStack
-        // which then leads to the next push appearing on top of existing (incorrect) stack
-        
-        // This is called when isPresented changes, and should only removeLast if isPresented = false
-        
-        if !isPresented && screenStack.count == (screenStackCount + 1) {
-//            screenStack.removeLast()
-        }
     }
     
     public func showAlert<T:View>(_ option: AlertOption, title: String, subtitle: String?, @ViewBuilder alert: @escaping () -> T, buttonsiOS13: [Alert.Button]?) {


### PR DESCRIPTION
Previously iOS 16 had a bug when screenStack would not update after a screen was dismissed. I had added a patch, but it seems that Apple may have fixed it internally (unclear). Regardless, this appears to be causing bugs in iOS 17 and is no longer needed.