### PR TITLE
showDragIndicator should be false by default + onDismiss implementation

### DIFF
--- a/Sources/SwiftfulRouting/Core/RouterView.swift
+++ b/Sources/SwiftfulRouting/Core/RouterView.swift
@@ -37,6 +37,8 @@ public struct RouterView<T:View>: View, Router {
 
     let addNavigationView: Bool
     let content: (AnyRouter) -> T
+    
+    let onDismiss: (() -> Void)?
  
     // Segues
     @State private var segueOption: SegueOption = .push
@@ -61,10 +63,11 @@ public struct RouterView<T:View>: View, Router {
     @State private var modalConfiguration: ModalConfiguration = .default
     @State private var modal: AnyDestination? = nil
     
-    public init(addNavigationView: Bool = true, screens: (Binding<[AnyDestination]>)? = nil, @ViewBuilder content: @escaping (AnyRouter) -> T) {
+    public init(addNavigationView: Bool = true, screens: (Binding<[AnyDestination]>)? = nil, onDismiss: (() -> Void)? = nil, @ViewBuilder content: @escaping (AnyRouter) -> T) {
         self.addNavigationView = addNavigationView
         self._screenStack = screens ?? .constant([])
         self._screenStackCount = State(wrappedValue: (screens?.wrappedValue.count ?? 0))
+        self.onDismiss = onDismiss
         self.content = content
     }
     
@@ -78,7 +81,8 @@ public struct RouterView<T:View>: View, Router {
                     sheetDetents: sheetDetents,
                     sheetSelection: sheetSelection,
                     sheetSelectionEnabled: sheetSelectionEnabled,
-                    showDragIndicator: showDragIndicator)
+                    showDragIndicator: showDragIndicator,
+                    onDismiss: onDismiss)
         }
         .showingAlert(option: alertOption, item: $alert)
         .showingModal(configuration: modalConfiguration, item: $modal)
@@ -231,7 +235,8 @@ extension View {
         sheetDetents: Set<PresentationDetentTransformable>,
         sheetSelection: Binding<PresentationDetentTransformable>,
         sheetSelectionEnabled: Bool,
-        showDragIndicator: Bool) -> some View {
+        showDragIndicator: Bool,
+        onDismiss: (() -> Void)?) -> some View {
             if #available(iOS 14, *) {
                 self
                     .modifier(NavigationLinkViewModifier(
@@ -245,11 +250,13 @@ extension View {
                         sheetDetents: sheetDetents,
                         sheetSelection: sheetSelection,
                         sheetSelectionEnabled: sheetSelectionEnabled,
-                        showDragIndicator: showDragIndicator
+                        showDragIndicator: showDragIndicator,
+                        onDismiss: onDismiss
                     ))
                     .modifier(FullScreenCoverViewModifier(
                         option: option,
-                        screens: screens
+                        screens: screens,
+                        onDismiss: onDismiss
                     ))
             } else {
                 self
@@ -264,7 +271,8 @@ extension View {
                         sheetDetents: sheetDetents,
                         sheetSelection: sheetSelection,
                         sheetSelectionEnabled: sheetSelectionEnabled,
-                        showDragIndicator: showDragIndicator
+                        showDragIndicator: showDragIndicator,
+                        onDismiss: onDismiss
                     ))
             }
     }

--- a/Sources/SwiftfulRouting/Core/RouterView.swift
+++ b/Sources/SwiftfulRouting/Core/RouterView.swift
@@ -51,7 +51,7 @@ public struct RouterView<T:View>: View, Router {
     @State private var sheetDetents: Set<PresentationDetentTransformable> = [.large]
     @State private var sheetSelection: Binding<PresentationDetentTransformable> = .constant(.large)
     @State private var sheetSelectionEnabled: Bool = false
-    @State private var showDragIndicator: Bool = true
+    @State private var showDragIndicator: Bool = false
 
     // Alerts
     @State private var alertOption: AlertOption = .alert
@@ -143,7 +143,7 @@ public struct RouterView<T:View>: View, Router {
     }
     
     @available(iOS 16, *)
-    public func showResizableSheet<V:View>(sheetDetents: Set<PresentationDetentTransformable>, selection: Binding<PresentationDetentTransformable>?, showDragIndicator: Bool = true, @ViewBuilder destination: @escaping (AnyRouter) -> V) {
+    public func showResizableSheet<V:View>(sheetDetents: Set<PresentationDetentTransformable>, selection: Binding<PresentationDetentTransformable>?, showDragIndicator: Bool = false, @ViewBuilder destination: @escaping (AnyRouter) -> V) {
         self.segueOption = .sheet
         self.sheetDetents = sheetDetents
         self.showDragIndicator = showDragIndicator

--- a/Sources/SwiftfulRouting/ViewModifiers/FullScreenCoverViewModifier.swift
+++ b/Sources/SwiftfulRouting/ViewModifiers/FullScreenCoverViewModifier.swift
@@ -13,10 +13,11 @@ struct FullScreenCoverViewModifier: ViewModifier {
     
     let option: SegueOption
     let screens: Binding<[AnyDestination]>
+    let onDismiss: (() -> Void)?
 
     func body(content: Content) -> some View {
         content
-            .fullScreenCover(item: Binding(if: option, is: .fullScreenCover, value: Binding(toLastElementIn: screens)), onDismiss: nil) { _ in
+            .fullScreenCover(item: Binding(if: option, is: .fullScreenCover, value: Binding(toLastElementIn: screens)), onDismiss: onDismiss) { _ in
                 if let view = screens.wrappedValue.last?.destination {
                     view
                 }

--- a/Sources/SwiftfulRouting/ViewModifiers/SheetViewModifier.swift
+++ b/Sources/SwiftfulRouting/ViewModifiers/SheetViewModifier.swift
@@ -16,10 +16,11 @@ struct SheetViewModifier: ViewModifier {
     @Binding var sheetSelection: PresentationDetentTransformable
     let sheetSelectionEnabled: Bool
     let showDragIndicator: Bool
+    let onDismiss: (() -> Void)?
 
     func body(content: Content) -> some View {
         content
-            .sheet(item: Binding(if: option, is: .sheet, value: Binding(toLastElementIn: screens)), onDismiss: nil) { destination in
+            .sheet(item: Binding(if: option, is: .sheet, value: Binding(toLastElementIn: screens)), onDismiss: onDismiss) { destination in
                 if let view = screens.wrappedValue.last?.destination {
                     view
                         .presentationDetentsIfNeeded(


### PR DESCRIPTION
Hello, I was unable to do two things with the library and this PR unlock these two things.

1. If you support OS prior to iOS 16 you can't hide the drag indicator in sheet. It should be false by default like when you present a native sheet. For example I had the drag indicator showing in a safari sheet view and the UI looks ugly:

![ugly_drag](https://github.com/SwiftfulThinking/SwiftfulRouting/assets/3198863/fba08ab7-45ae-4cd5-ae56-d79761816065)

In this case you don't wanna show the dragIndicator.

2. Both fullscreenCover and sheet have onDismiss at nil and you can't override this. I don't know if it's was on purpose but I added the possibility to pass an onDismiss completion handler. It was mandatory for me to have some logic after my sheet is dismissed.

Thanks!