### PR TITLE
Bug fixs

### DIFF
--- a/Sources/SwiftfulRouting/Components/TransitionSupportView.swift
+++ b/Sources/SwiftfulRouting/Components/TransitionSupportView.swift
@@ -28,7 +28,6 @@ struct TransitionSupportView<Content:View>: View {
                 return Group {
                     if data == transitions.first {
                         content(router)
-//                            .id(routerId)
                     } else {
                         if allowsSwipeBack {
                             SwipeBackSupportContainer(

--- a/Sources/SwiftfulRouting/Components/TransitionSupportView.swift
+++ b/Sources/SwiftfulRouting/Components/TransitionSupportView.swift
@@ -10,7 +10,6 @@ import SwiftfulRecursiveUI
 
 struct TransitionSupportView<Content:View>: View {
     
-    var routerId: String
     var behavior: TransitionMemoryBehavior = .keepPrevious
     let router: AnyRouter
     let transitions: [AnyTransitionDestination]
@@ -29,7 +28,7 @@ struct TransitionSupportView<Content:View>: View {
                 return Group {
                     if data == transitions.first {
                         content(router)
-                            .id(routerId)
+//                            .id(routerId)
                     } else {
                         if allowsSwipeBack {
                             SwipeBackSupportContainer(

--- a/Sources/SwiftfulRouting/Components/TransitionSupportView.swift
+++ b/Sources/SwiftfulRouting/Components/TransitionSupportView.swift
@@ -10,6 +10,7 @@ import SwiftfulRecursiveUI
 
 struct TransitionSupportView<Content:View>: View {
     
+    var routerId: String
     var behavior: TransitionMemoryBehavior = .keepPrevious
     let router: AnyRouter
     let transitions: [AnyTransitionDestination]
@@ -28,6 +29,7 @@ struct TransitionSupportView<Content:View>: View {
                 return Group {
                     if data == transitions.first {
                         content(router)
+                            .id(routerId)
                     } else {
                         if allowsSwipeBack {
                             SwipeBackSupportContainer(

--- a/Sources/SwiftfulRouting/Core/RouterProtocol/AnyRouter.swift
+++ b/Sources/SwiftfulRouting/Core/RouterProtocol/AnyRouter.swift
@@ -9,9 +9,11 @@ import SwiftUI
 
 /// Type-erased Router with convenience methods.
 public struct AnyRouter: Sendable, Router {
+    public let id: String
     private let object: any Router
 
-    init(object: any Router) {
+    init(id: String, object: any Router) {
+        self.id = id
         self.object = object
     }
     
@@ -607,4 +609,14 @@ public struct AnyRouter: Sendable, Router {
         object.showSafari(url)
     }
 
+}
+
+extension AnyRouter: Identifiable, Hashable, Equatable {
+    public static func == (lhs: AnyRouter, rhs: AnyRouter) -> Bool {
+        lhs.id == rhs.id // or compare the underlying object identity
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id) // or use ObjectIdentifier
+    }
 }

--- a/Sources/SwiftfulRouting/Core/RouterProtocol/AnyRouter.swift
+++ b/Sources/SwiftfulRouting/Core/RouterProtocol/AnyRouter.swift
@@ -611,12 +611,14 @@ public struct AnyRouter: Sendable, Router {
 
 }
 
+// Used to stabilize View updates (Issue #92)
 extension AnyRouter: Identifiable, Hashable, Equatable {
+
     public static func == (lhs: AnyRouter, rhs: AnyRouter) -> Bool {
-        lhs.id == rhs.id // or compare the underlying object identity
+        lhs.id == rhs.id
     }
 
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(id) // or use ObjectIdentifier
+        hasher.combine(id)
     }
 }

--- a/Sources/SwiftfulRouting/Core/RouterProtocol/RouterEnvironmentKey.swift
+++ b/Sources/SwiftfulRouting/Core/RouterProtocol/RouterEnvironmentKey.swift
@@ -7,7 +7,7 @@
 import SwiftUI
 
 public struct RouterEnvironmentKey: EnvironmentKey {
-    public static let defaultValue: AnyRouter = AnyRouter(object: MockRouter())
+    public static let defaultValue: AnyRouter = AnyRouter(id: "mock", object: MockRouter())
 }
 
 public extension EnvironmentValues {

--- a/Sources/SwiftfulRouting/Core/RouterViews/RouterViewInternal.swift
+++ b/Sources/SwiftfulRouting/Core/RouterViews/RouterViewInternal.swift
@@ -31,7 +31,7 @@ struct RouterViewInternal<Content: View>: View, Router {
     var addNavigationStack: Bool = false
     var content: (AnyRouter) -> Content
 
-    @State private var stableScreenStack: [AnyDestination] = []
+    @StateObject private var stableScreenStack = StablePath(destinations: [])
 
     private var currentRouter: AnyRouter {
         AnyRouter(id: routerId, object: self)
@@ -53,12 +53,12 @@ struct RouterViewInternal<Content: View>: View, Router {
         
         // Add NavigationStack if needed
         .ifSatisfiesCondition(addNavigationStack, transform: { content in
-            NavigationStack(path: $stableScreenStack) {
+            NavigationStack(path: $stableScreenStack.destinations) {
                 content
                     .navigationDestination(for: AnyDestination.self) { value in
                         value.destination
                     }
-                    .onChange(of: stableScreenStack, perform: { screenStack in
+                    .onChange(of: stableScreenStack.destinations, perform: { screenStack in
                         // User manually swiped back on screen
                         
                         let activeStack = viewModel.activeScreenStacks
@@ -85,16 +85,16 @@ struct RouterViewInternal<Content: View>: View, Router {
                             return subStack.screens.contains(where: { $0.id == routerId })
                         }
                         guard let index, newStack.indices.contains(index + 1) else {
-                            if !stableScreenStack.isEmpty {
-                                stableScreenStack = []
+                            if !stableScreenStack.destinations.isEmpty {
+                                stableScreenStack.destinations = []
                                 print("SET STACK TO ZERO")
                             }
                             return
                         }
                         
                         let activeStack = newStack[index + 1].screens
-                        if stableScreenStack != activeStack {
-                            stableScreenStack = activeStack
+                        if stableScreenStack.destinations != activeStack {
+                            stableScreenStack.destinations = activeStack
                             print("SET STACK TOOO: \(activeStack.count)")
                         }
 //                        let index = newStack.firstIndex { $0.screens.contains { $0.id == routerId } }

--- a/Sources/SwiftfulRouting/Core/RouterViews/RouterViewInternal.swift
+++ b/Sources/SwiftfulRouting/Core/RouterViews/RouterViewInternal.swift
@@ -43,6 +43,27 @@ struct RouterViewInternal<Content: View>: View, Router {
                     .navigationDestination(for: AnyDestination.self) { value in
                         value.destination
                     }
+                    .onChange(of: stableScreenStack, perform: { screenStack in
+                        // User manually swiped back on screen
+                        
+                        let activeStack = viewModel.activeScreenStacks
+                        let index = activeStack.firstIndex { subStack in
+                            return subStack.screens.contains(where: { $0.id == routerId })
+                        }
+                        guard let index, activeStack.indices.contains(index + 1) else {
+                            return
+                        }
+
+                        if screenStack.count < activeStack[index + 1].screens.count {
+                            if let lastScreen = screenStack.last {
+                                viewModel.dismissScreens(to: lastScreen.id, animates: true)
+                                print("DISMISS TO LAST SCREEN ID")
+                            } else {
+                                viewModel.dismissPushStack(routeId: routerId, animates: true)
+                                print("DISMISS PUSH STACK")
+                            }
+                        }
+                    })
                     .onChange(of: viewModel.activeScreenStacks) { newStack in
                         
                         let index = newStack.firstIndex { subStack in
@@ -50,13 +71,13 @@ struct RouterViewInternal<Content: View>: View, Router {
                         }
                         guard let index, newStack.indices.contains(index + 1) else {
                             stableScreenStack = []
+                            print("SET STACK TO ZERO")
                             return
                         }
                         
                         let activeStack = newStack[index + 1].screens
                         stableScreenStack = activeStack
-
-                        
+                        print("SET STACK TOOO: \(activeStack.count)")
 //                        let index = newStack.firstIndex { $0.screens.contains { $0.id == routerId } }
 //                        if let index, newStack.indices.contains(index + 1) {
 //                            let newScreens = newStack[index + 1].screens

--- a/Sources/SwiftfulRouting/Core/RouterViews/RouterViewInternal.swift
+++ b/Sources/SwiftfulRouting/Core/RouterViews/RouterViewInternal.swift
@@ -40,6 +40,7 @@ struct RouterViewInternal<Content: View>: View, Router {
     var body: some View {
         // Wrap starting content for Transition support
         TransitionSupportView(
+            routerId: routerId,
             behavior: parentDestination?.transitionBehavior ?? .keepPrevious,
             router: currentRouter,
             transitions: viewModel.allTransitions[routerId] ?? [],
@@ -49,8 +50,6 @@ struct RouterViewInternal<Content: View>: View, Router {
                 dismissTransition()
             }
         )
-        // Stabilizes view
-        .id(routerId)
         
         // Add NavigationStack if needed
         .ifSatisfiesCondition(addNavigationStack, transform: { content in

--- a/Sources/SwiftfulRouting/Core/RouterViews/RouterViewInternal.swift
+++ b/Sources/SwiftfulRouting/Core/RouterViews/RouterViewInternal.swift
@@ -76,8 +76,10 @@ struct RouterViewInternal<Content: View>: View, Router {
                         }
                         
                         let activeStack = newStack[index + 1].screens
-                        stableScreenStack = activeStack
-                        print("SET STACK TOOO: \(activeStack.count)")
+                        if stableScreenStack != activeStack {
+                            stableScreenStack = activeStack
+                            print("SET STACK TOOO: \(activeStack.count)")
+                        }
 //                        let index = newStack.firstIndex { $0.screens.contains { $0.id == routerId } }
 //                        if let index, newStack.indices.contains(index + 1) {
 //                            let newScreens = newStack[index + 1].screens

--- a/Sources/SwiftfulRouting/Core/RouterViews/RouterViewInternal.swift
+++ b/Sources/SwiftfulRouting/Core/RouterViews/RouterViewInternal.swift
@@ -49,13 +49,15 @@ struct RouterViewInternal<Content: View>: View, Router {
                 dismissTransition()
             }
         )
+        // Stabilizes view
+        .id(routerId)
+        
         // Add NavigationStack if needed
         .ifSatisfiesCondition(addNavigationStack, transform: { content in
             NavigationStack(path: $stableScreenStack.destinations) {
                 content
                     .navigationDestination(for: AnyDestination.self) { value in
                         value.destination
-                            .id(value.id)
                     }
                     .onChange(of: stableScreenStack.destinations, perform: { screenStack in
                         // User manually swiped back on screen

--- a/Sources/SwiftfulRouting/Core/RouterViews/RouterViewInternal.swift
+++ b/Sources/SwiftfulRouting/Core/RouterViews/RouterViewInternal.swift
@@ -40,7 +40,6 @@ struct RouterViewInternal<Content: View>: View, Router {
     var body: some View {
         // Wrap starting content for Transition support
         TransitionSupportView(
-            routerId: routerId,
             behavior: parentDestination?.transitionBehavior ?? .keepPrevious,
             router: currentRouter,
             transitions: viewModel.allTransitions[routerId] ?? [],

--- a/Sources/SwiftfulRouting/Core/RouterViews/RouterViewInternal.swift
+++ b/Sources/SwiftfulRouting/Core/RouterViews/RouterViewInternal.swift
@@ -49,6 +49,7 @@ struct RouterViewInternal<Content: View>: View, Router {
                 dismissTransition()
             }
         )
+        .id(routerId)
         
         // Add NavigationStack if needed
         .ifSatisfiesCondition(addNavigationStack, transform: { content in

--- a/Sources/SwiftfulRouting/Core/RouterViews/RouterViewInternal.swift
+++ b/Sources/SwiftfulRouting/Core/RouterViews/RouterViewInternal.swift
@@ -34,7 +34,7 @@ struct RouterViewInternal<Content: View>: View, Router {
     @StateObject private var stableScreenStack = StablePath(destinations: [])
 
     private var currentRouter: AnyRouter {
-        AnyRouter(object: self)
+        AnyRouter(id: routerId, object: self)
     }
     
     var body: some View {

--- a/Sources/SwiftfulRouting/Core/RouterViews/RouterViewInternal.swift
+++ b/Sources/SwiftfulRouting/Core/RouterViews/RouterViewInternal.swift
@@ -55,6 +55,7 @@ struct RouterViewInternal<Content: View>: View, Router {
                 content
                     .navigationDestination(for: AnyDestination.self) { value in
                         value.destination
+                            .id(value.id)
                     }
                     .onChange(of: stableScreenStack.destinations, perform: { screenStack in
                         // User manually swiped back on screen

--- a/Sources/SwiftfulRouting/Core/RouterViews/RouterViewInternal.swift
+++ b/Sources/SwiftfulRouting/Core/RouterViews/RouterViewInternal.swift
@@ -31,7 +31,7 @@ struct RouterViewInternal<Content: View>: View, Router {
     var addNavigationStack: Bool = false
     var content: (AnyRouter) -> Content
 
-    @StateObject private var stableScreenStack = StablePath(destinations: [])
+    @State private var stableScreenStack: [AnyDestination] = []
 
     private var currentRouter: AnyRouter {
         AnyRouter(id: routerId, object: self)
@@ -53,12 +53,12 @@ struct RouterViewInternal<Content: View>: View, Router {
         
         // Add NavigationStack if needed
         .ifSatisfiesCondition(addNavigationStack, transform: { content in
-            NavigationStack(path: $stableScreenStack.destinations) {
+            NavigationStack(path: $stableScreenStack) {
                 content
                     .navigationDestination(for: AnyDestination.self) { value in
                         value.destination
                     }
-                    .onChange(of: stableScreenStack.destinations, perform: { screenStack in
+                    .onChange(of: stableScreenStack, perform: { screenStack in
                         // User manually swiped back on screen
                         
                         let activeStack = viewModel.activeScreenStacks
@@ -85,16 +85,16 @@ struct RouterViewInternal<Content: View>: View, Router {
                             return subStack.screens.contains(where: { $0.id == routerId })
                         }
                         guard let index, newStack.indices.contains(index + 1) else {
-                            if !stableScreenStack.destinations.isEmpty {
-                                stableScreenStack.destinations = []
+                            if !stableScreenStack.isEmpty {
+                                stableScreenStack = []
                                 print("SET STACK TO ZERO")
                             }
                             return
                         }
                         
                         let activeStack = newStack[index + 1].screens
-                        if stableScreenStack.destinations != activeStack {
-                            stableScreenStack.destinations = activeStack
+                        if stableScreenStack != activeStack {
+                            stableScreenStack = activeStack
                             print("SET STACK TOOO: \(activeStack.count)")
                         }
 //                        let index = newStack.firstIndex { $0.screens.contains { $0.id == routerId } }

--- a/Sources/SwiftfulRouting/Extensions/Binding+EXT.swift
+++ b/Sources/SwiftfulRouting/Extensions/Binding+EXT.swift
@@ -8,34 +8,34 @@
 import Foundation
 import SwiftUI
 
-@MainActor
-extension Binding where Value == [AnyDestination] {
-    
-    init(stack: [AnyDestinationStack], routerId: String, onDidDismiss: @escaping (_ lastRouteRemaining: AnyDestination?) -> Void) {
-        self.init {
-            let index = stack.firstIndex { subStack in
-                return subStack.screens.contains(where: { $0.id == routerId })
-            }
-            guard let index, stack.indices.contains(index + 1) else {
-                return []
-            }
-            return stack[index + 1].screens
-        } set: { newValue in
-            // User manually swiped back on screen
-            
-            let index = stack.firstIndex { subStack in
-                return subStack.screens.contains(where: { $0.id == routerId })
-            }
-            guard let index, stack.indices.contains(index + 1) else {
-                return
-            }
-            
-            if newValue.count < stack[index + 1].screens.count {
-                onDidDismiss(newValue.last)
-            }
-        }
-    }
-}
+//@MainActor
+//extension Binding where Value == [AnyDestination] {
+//    
+//    init(stack: [AnyDestinationStack], routerId: String, onDidDismiss: @escaping (_ lastRouteRemaining: AnyDestination?) -> Void) {
+//        self.init {
+//            let index = stack.firstIndex { subStack in
+//                return subStack.screens.contains(where: { $0.id == routerId })
+//            }
+//            guard let index, stack.indices.contains(index + 1) else {
+//                return []
+//            }
+//            return stack[index + 1].screens
+//        } set: { newValue in
+//            // User manually swiped back on screen
+//            
+//            let index = stack.firstIndex { subStack in
+//                return subStack.screens.contains(where: { $0.id == routerId })
+//            }
+//            guard let index, stack.indices.contains(index + 1) else {
+//                return
+//            }
+//            
+//            if newValue.count < stack[index + 1].screens.count {
+//                onDidDismiss(newValue.last)
+//            }
+//        }
+//    }
+//}
 
 @MainActor
 extension Binding where Value == AnyDestination? {

--- a/Sources/SwiftfulRouting/Models/Screens/StableAnyDestinationArray.swift
+++ b/Sources/SwiftfulRouting/Models/Screens/StableAnyDestinationArray.swift
@@ -1,0 +1,25 @@
+//
+//  StablePath.swift
+//  SwiftfulRouting
+//
+//  Created by Nick Sarno on 5/22/25.
+//
+import SwiftUI
+
+final class StableAnyDestinationArray: ObservableObject, Equatable {
+    @Published var destinations: [AnyDestination]
+
+    init(destinations: [AnyDestination]) {
+        self.destinations = destinations
+    }
+    
+    func setNewValueIfNeeded(newValue: [AnyDestination]) {
+        if destinations != newValue {
+            destinations = newValue
+        }
+    }
+
+    static func == (lhs: StableAnyDestinationArray, rhs: StableAnyDestinationArray) -> Bool {
+        lhs === rhs
+    }
+}


### PR DESCRIPTION
Fix #92 & #93 

#92 - When navigating between screens, AnyRouter was being unnecessarily recreated. Solution was to conform AnyRouter to Hashable and Equatable. Also added a View .id() to remove an extra unrelated render. 

#93 - SwiftUI lifecycle was re-evaluating `Binding where Value == [AnyDestination]` every segue and could not recognize duplicate results. Move to using `StableAnyDestinationArray` as a local Binding in the View.