### PR TITLE
[Feature] Fix Sheet Bug

### DIFF
--- a/Sources/SwiftfulRouting/Core/RouterViews/RouterViewInternal.swift
+++ b/Sources/SwiftfulRouting/Core/RouterViews/RouterViewInternal.swift
@@ -52,33 +52,21 @@ struct RouterViewInternal<Content: View>: View, Router {
                     .onChange(of: viewModel.activeScreenStacks) { newStack in
                         handleActiveScreenStackDidChange(newStack: newStack)
                     }
+                
+                    // There's a weird behavior (bug?) where the presentationDetent is not calculated
+                    // If the .sheet modifier is outside of the NavigationStack
+                    // Therefore, if we add NavigationStack, we add these as children of it
+                    .sheetBackgroundModifier(viewModel: viewModel, routerId: routerId)
+                    .fullScreenCoverBackgroundModifer(viewModel: viewModel, routerId: routerId)
             }
         })
-        // Add Sheet modifier. Add on background to supress OS warnings.
-        .background(
-            Text("")
-                .sheet(item: Binding(stack: viewModel.activeScreenStacks, routerId: routerId, segue: .sheet, onDidDismiss: {
-                    // This triggers if the user swipes down to dismiss the screen
-                    // Now we must update activeScreenStacks to match that behavior
-                    viewModel.dismissScreens(toEnvironmentId: routerId, animates: true)
-                }), onDismiss: nil) { destination in
-                    destination.destination
-                        .applyResizableSheetModifiersIfNeeded(segue: destination.segue)
-                }
-        )
         
-        // Add FullScreenCover modifier. Add on background to supress OS warnings.
-        .background(
-            Text("")
-                .fullScreenCover(item: Binding(stack: viewModel.activeScreenStacks, routerId: routerId, segue: .fullScreenCover, onDidDismiss: {
-                    // This triggers if the user swipes down to dismiss the screen
-                    // Now we must update activeScreenStacks to match that behavior
-                    viewModel.dismissScreens(toEnvironmentId: routerId, animates: true)
-                }), onDismiss: nil) { destination in
-                    destination.destination
-                        .applyResizableSheetModifiersIfNeeded(segue: destination.segue)
-                }
-        )
+        // If we don't add NavigationStack, add .sheet modifiers here instead
+        .ifSatisfiesCondition(!addNavigationStack, transform: { content in
+            content
+                .sheetBackgroundModifier(viewModel: viewModel, routerId: routerId)
+                .fullScreenCoverBackgroundModifer(viewModel: viewModel, routerId: routerId)
+        })
         
         // If this is the root router, add "root" stack to the array
         .ifSatisfiesCondition(routerId == RouterViewModel.rootId, transform: { content in
@@ -377,5 +365,38 @@ struct RouterViewInternal<Content: View>: View, Router {
         let url = url()
         openURL(url)
         logger.trackEvent(event: RouterViewModel.Event.showSafari(url: url))
+    }
+}
+
+extension View {
+    
+    func sheetBackgroundModifier(viewModel: RouterViewModel, routerId: String) -> some View {
+        self
+            .background(
+                Text("")
+                    .sheet(item: Binding(stack: viewModel.activeScreenStacks, routerId: routerId, segue: .sheet, onDidDismiss: {
+                        // This triggers if the user swipes down to dismiss the screen
+                        // Now we must update activeScreenStacks to match that behavior
+                        viewModel.dismissScreens(toEnvironmentId: routerId, animates: true)
+                    }), onDismiss: nil) { destination in
+                        destination.destination
+                            .applyResizableSheetModifiersIfNeeded(segue: destination.segue)
+                    }
+            )
+    }
+    
+    func fullScreenCoverBackgroundModifer(viewModel: RouterViewModel, routerId: String) -> some View {
+        self
+            .background(
+                Text("")
+                    .fullScreenCover(item: Binding(stack: viewModel.activeScreenStacks, routerId: routerId, segue: .fullScreenCover, onDidDismiss: {
+                        // This triggers if the user swipes down to dismiss the screen
+                        // Now we must update activeScreenStacks to match that behavior
+                        viewModel.dismissScreens(toEnvironmentId: routerId, animates: true)
+                    }), onDismiss: nil) { destination in
+                        destination.destination
+                            .applyResizableSheetModifiersIfNeeded(segue: destination.segue)
+                    }
+            )
     }
 }


### PR DESCRIPTION
Fix for #95 

When adding a new `NavigationStack` to the hierarchy, SwiftUI may miscalculate the `presentationDetent` of a child resizable sheet (seems like a bug).

The solution herein is: when adding a new `NavigationStack`, include the `.sheet` modifiers _inside_ the new NavigationStack, rather than `outside`.

```swift
// Before
NavigationStack {
    content
}
.sheet(...)
```

```swift
// After
NavigationStack {
    content
        .sheet(...)
}
```