### PR TITLE
Add ModalLocation with true cross-RouterViewModel .topRouter support

### DIFF
--- a/.claude/swiftful-routing-rules.md
+++ b/.claude/swiftful-routing-rules.md
@@ -279,6 +279,7 @@ router.showBottomModal {
 ```swift
 router.showModal(
     id: String = UUID().uuidString,
+    location: ModalLocation = .currentRouter,    // .currentRouter (default) or .topRouter
     transition: AnyTransition = .identity,       // .opacity, .move(edge:), .scale, .slide, .identity
     animation: Animation = .smooth,              // .smooth, .easeInOut, .spring(), etc.
     alignment: Alignment = .center,              // .center, .bottom, .top, .leading, .trailing
@@ -289,6 +290,35 @@ router.showModal(
     onDismiss: (() -> Void)? = nil,
     destination: @escaping () -> some View
 )
+```
+
+### Modal location
+
+**Default to `.currentRouter`.** Only use `.topRouter` when the user explicitly says the modal is appearing behind the tab bar or behind some other persistent UI layer. The typical symptom is: "the modal shows up but the tab bar is in front of it."
+
+`.topRouter` works by reading the topmost `RouterViewModel` from the SwiftUI environment. When multiple `RouterView` instances are nested (e.g. a root `RouterView` wrapping a tab bar, each tab also having its own `RouterView`), `.topRouter` targets the outermost one — so the modal renders above everything including the tab bar.
+
+```swift
+// Default — modal appears on the current screen (use this unless told otherwise)
+router.showModal {
+    MyModal()
+}
+
+// Only when user reports the tab bar is covering the modal
+router.showModal(location: .topRouter) {
+    MyModal()
+}
+```
+
+All dismiss methods also accept `location` with the same default:
+
+```swift
+router.dismissModal()                                        // current router (default)
+router.dismissModal(location: .topRouter)                    // root RouterView
+router.dismissModal(id: "modal_id", location: .topRouter)
+router.dismissModals(count: 2, location: .topRouter)
+router.dismissModals(upToId: "modal_id", location: .topRouter)
+router.dismissAllModals(location: .topRouter)
 ```
 
 ### Background blur effect
@@ -313,11 +343,12 @@ router.showModal(
 ### Dismiss modals
 
 ```swift
-router.dismissModal()                           // dismiss top modal
+router.dismissModal()                           // dismiss top modal on current router
 router.dismissModal(id: "modal_id")             // dismiss specific modal
 router.dismissModals(count: 2)                  // dismiss last N modals
 router.dismissModals(upToId: "modal_id")        // dismiss down to specific modal
 router.dismissAllModals()                       // dismiss all modals
+// All of the above accept location: .topRouter to target the root RouterView
 ```
 
 ## Transitions (showTransition)

--- a/.claude/swiftful-routing-rules.md
+++ b/.claude/swiftful-routing-rules.md
@@ -279,7 +279,7 @@ router.showBottomModal {
 ```swift
 router.showModal(
     id: String = UUID().uuidString,
-    location: ModalLocation = .currentRouter,    // .currentRouter (default) or .topRouter
+    location: ModalLocation = .currentRouter,    // .currentRouter (default) or .rootRouter
     transition: AnyTransition = .identity,       // .opacity, .move(edge:), .scale, .slide, .identity
     animation: Animation = .smooth,              // .smooth, .easeInOut, .spring(), etc.
     alignment: Alignment = .center,              // .center, .bottom, .top, .leading, .trailing
@@ -294,9 +294,9 @@ router.showModal(
 
 ### Modal location
 
-**Default to `.currentRouter`.** Only use `.topRouter` when the user explicitly says the modal is appearing behind the tab bar or behind some other persistent UI layer. The typical symptom is: "the modal shows up but the tab bar is in front of it."
+**Default to `.currentRouter`.** Only use `.rootRouter` when the user explicitly says the modal is appearing behind the tab bar or behind some other persistent UI layer. The typical symptom is: "the modal shows up but the tab bar is in front of it."
 
-`.topRouter` works by reading the topmost `RouterViewModel` from the SwiftUI environment. When multiple `RouterView` instances are nested (e.g. a root `RouterView` wrapping a tab bar, each tab also having its own `RouterView`), `.topRouter` targets the outermost one — so the modal renders above everything including the tab bar.
+`.rootRouter` works by reading the topmost `RouterViewModel` from the SwiftUI environment. When multiple `RouterView` instances are nested (e.g. a root `RouterView` wrapping a tab bar, each tab also having its own `RouterView`), `.rootRouter` targets the outermost one — so the modal renders above everything including the tab bar.
 
 ```swift
 // Default — modal appears on the current screen (use this unless told otherwise)
@@ -305,7 +305,7 @@ router.showModal {
 }
 
 // Only when user reports the tab bar is covering the modal
-router.showModal(location: .topRouter) {
+router.showModal(location: .rootRouter) {
     MyModal()
 }
 ```
@@ -314,11 +314,11 @@ All dismiss methods also accept `location` with the same default:
 
 ```swift
 router.dismissModal()                                        // current router (default)
-router.dismissModal(location: .topRouter)                    // root RouterView
-router.dismissModal(id: "modal_id", location: .topRouter)
-router.dismissModals(count: 2, location: .topRouter)
-router.dismissModals(upToId: "modal_id", location: .topRouter)
-router.dismissAllModals(location: .topRouter)
+router.dismissModal(location: .rootRouter)                    // root RouterView
+router.dismissModal(id: "modal_id", location: .rootRouter)
+router.dismissModals(count: 2, location: .rootRouter)
+router.dismissModals(upToId: "modal_id", location: .rootRouter)
+router.dismissAllModals(location: .rootRouter)
 ```
 
 ### Background blur effect
@@ -348,7 +348,7 @@ router.dismissModal(id: "modal_id")             // dismiss specific modal
 router.dismissModals(count: 2)                  // dismiss last N modals
 router.dismissModals(upToId: "modal_id")        // dismiss down to specific modal
 router.dismissAllModals()                       // dismiss all modals
-// All of the above accept location: .topRouter to target the root RouterView
+// All of the above accept location: .rootRouter to target the root RouterView
 ```
 
 ## Transitions (showTransition)

--- a/README.md
+++ b/README.md
@@ -604,6 +604,7 @@ Fully customize modal's display.
 ```swift
 router.showModal(
     id: "modal_1", // Id for modal
+    location: .currentRouter, // Which RouterView to display modal on
     transition: .move(edge: .bottom), // AnyTransition
     animation: .smooth, // transition animation
     alignment: .center, // Alignment within screen
@@ -620,10 +621,18 @@ router.showModal(
 )
 ```
 
+Use `location: .topRouter` to display the modal on the root `RouterView`, above all nested routers. This is useful in tab-based apps where each tab has its own `RouterView` and the modal should appear above the tab bar.
+
+```swift
+router.showModal(location: .topRouter) {
+    MyModal()
+}
+```
+
 Modal methods also accept `AnyModal` as a convenience.
 
 ```
-let modal = AnyModal {
+let modal = AnyModal(location: .topRouter) {
     MyModal()
 }
 
@@ -636,34 +645,23 @@ Trigger multiple modals at the same time.
 router.showModals(modals: [modal1, modal2])
 ```
 
-Dismiss the last modal displayed.
+All dismiss methods accept an optional `location` parameter (`.currentRouter` by default).
 
 ```swift
 router.dismissModal()
-```
+router.dismissModal(location: .topRouter)
 
-Dismiss modal by id.
-
-```swift
 router.dismissModal(id: "modal_1")
-```
+router.dismissModal(id: "modal_1", location: .topRouter)
 
-Dismiss modals above, but not including, id.
+router.dismissModals(upToId: "modal_1")
+router.dismissModals(upToId: "modal_1", location: .topRouter)
 
-```swift
-router.dismissModals(upToModalId: "modal_1")
-```
-
-Dismiss specific number of modals.
-
-```swift
 router.dismissModals(count: 2)
-```
+router.dismissModals(count: 2, location: .topRouter)
 
-Dismiss all modals.
-
-```swift
 router.dismissAllModals()
+router.dismissAllModals(location: .topRouter)
 ```
 
 Additional convenience methods:

--- a/README.md
+++ b/README.md
@@ -621,10 +621,10 @@ router.showModal(
 )
 ```
 
-Use `location: .topRouter` to display the modal on the root `RouterView`, above all nested routers. This is useful in tab-based apps where each tab has its own `RouterView` and the modal should appear above the tab bar.
+Use `location: .rootRouter` to display the modal on the root `RouterView`, above all nested routers. This is useful in tab-based apps where each tab has its own `RouterView` and the modal should appear above the tab bar.
 
 ```swift
-router.showModal(location: .topRouter) {
+router.showModal(location: .rootRouter) {
     MyModal()
 }
 ```
@@ -632,7 +632,7 @@ router.showModal(location: .topRouter) {
 Modal methods also accept `AnyModal` as a convenience.
 
 ```
-let modal = AnyModal(location: .topRouter) {
+let modal = AnyModal(location: .rootRouter) {
     MyModal()
 }
 
@@ -649,19 +649,19 @@ All dismiss methods accept an optional `location` parameter (`.currentRouter` by
 
 ```swift
 router.dismissModal()
-router.dismissModal(location: .topRouter)
+router.dismissModal(location: .rootRouter)
 
 router.dismissModal(id: "modal_1")
-router.dismissModal(id: "modal_1", location: .topRouter)
+router.dismissModal(id: "modal_1", location: .rootRouter)
 
 router.dismissModals(upToId: "modal_1")
-router.dismissModals(upToId: "modal_1", location: .topRouter)
+router.dismissModals(upToId: "modal_1", location: .rootRouter)
 
 router.dismissModals(count: 2)
-router.dismissModals(count: 2, location: .topRouter)
+router.dismissModals(count: 2, location: .rootRouter)
 
 router.dismissAllModals()
-router.dismissAllModals(location: .topRouter)
+router.dismissAllModals(location: .rootRouter)
 ```
 
 Additional convenience methods:

--- a/Sources/SwiftfulRouting/Core/RouterProtocol/AnyRouter.swift
+++ b/Sources/SwiftfulRouting/Core/RouterProtocol/AnyRouter.swift
@@ -317,6 +317,7 @@ public struct AnyRouter: Sendable, Router {
     /// Show a modal.
     /// - Parameters:
     ///   - id: Identifier for modal.
+    ///   - location: Which router to display modal on. Use .topRouter to show on the root RouterView, above all nested routers (e.g. above a tab bar).
     ///   - transition: Transition to show and hide modal.
     ///   - animation: Animation to show and hide modal.
     ///   - alignment: Alignment within the screen.
@@ -328,6 +329,7 @@ public struct AnyRouter: Sendable, Router {
     ///   - destination: The modal View.
     @MainActor public func showModal<T>(
         id: String = UUID().uuidString,
+        location: ModalLocation = .currentRouter,
         transition: AnyTransition = .identity,
         animation: Animation = .smooth,
         alignment: Alignment = .center,
@@ -340,6 +342,7 @@ public struct AnyRouter: Sendable, Router {
     ) where T : View {
             let modal = AnyModal(
                 id: id,
+                location: location,
                 transition: transition,
                 animation: animation,
                 alignment: alignment,
@@ -397,28 +400,29 @@ public struct AnyRouter: Sendable, Router {
     }
     
     /// Dismiss the last modal displayed on this screen.
-    @MainActor public func dismissModal() {
-        object.dismissModal()
+    /// - Parameter location: Which router's modal to dismiss. Use .topRouter to target the root RouterView.
+    @MainActor public func dismissModal(location: ModalLocation = .currentRouter) {
+        object.dismissModal(location: location)
     }
-    
+
     /// Dismiss the modal at id on this screen.
-    @MainActor public func dismissModal(id: String) {
-        object.dismissModal(id: id)
+    @MainActor public func dismissModal(id: String, location: ModalLocation = .currentRouter) {
+        object.dismissModal(id: id, location: location)
     }
-    
+
     /// Dismiss all modals in front of, but not including, modal id on this screen.
-    @MainActor public func dismissModals(upToId: String) {
-        object.dismissModals(upToId: upToId)
+    @MainActor public func dismissModals(upToId: String, location: ModalLocation = .currentRouter) {
+        object.dismissModals(upToId: upToId, location: location)
     }
-    
+
     /// Dismiss specific number modals on this screen.
-    @MainActor public func dismissModals(count: Int) {
-        object.dismissModals(count: count)
+    @MainActor public func dismissModals(count: Int, location: ModalLocation = .currentRouter) {
+        object.dismissModals(count: count, location: location)
     }
-    
+
     /// Dismiss all modals on this screen.
-    @MainActor public func dismissAllModals() {
-        object.dismissAllModals()
+    @MainActor public func dismissAllModals(location: ModalLocation = .currentRouter) {
+        object.dismissAllModals(location: location)
     }
     
     /// Transition current screen.

--- a/Sources/SwiftfulRouting/Core/RouterProtocol/AnyRouter.swift
+++ b/Sources/SwiftfulRouting/Core/RouterProtocol/AnyRouter.swift
@@ -317,7 +317,7 @@ public struct AnyRouter: Sendable, Router {
     /// Show a modal.
     /// - Parameters:
     ///   - id: Identifier for modal.
-    ///   - location: Which router to display modal on. Use .topRouter to show on the root RouterView, above all nested routers (e.g. above a tab bar).
+    ///   - location: Which router to display modal on. Use .rootRouter to show on the root RouterView, above all nested routers (e.g. above a tab bar).
     ///   - transition: Transition to show and hide modal.
     ///   - animation: Animation to show and hide modal.
     ///   - alignment: Alignment within the screen.
@@ -400,7 +400,7 @@ public struct AnyRouter: Sendable, Router {
     }
     
     /// Dismiss the last modal displayed on this screen.
-    /// - Parameter location: Which router's modal to dismiss. Use .topRouter to target the root RouterView.
+    /// - Parameter location: Which router's modal to dismiss. Use .rootRouter to target the root RouterView.
     @MainActor public func dismissModal(location: ModalLocation = .currentRouter) {
         object.dismissModal(location: location)
     }

--- a/Sources/SwiftfulRouting/Core/RouterProtocol/MockRouter.swift
+++ b/Sources/SwiftfulRouting/Core/RouterProtocol/MockRouter.swift
@@ -124,23 +124,23 @@ struct MockRouter: Router {
         printError()
     }
     
-    func dismissModal() {
+    func dismissModal(location: ModalLocation = .currentRouter) {
         printError()
     }
-    
-    func dismissModal(id: String) {
+
+    func dismissModal(id: String, location: ModalLocation = .currentRouter) {
         printError()
     }
-    
-    func dismissModals(upToId: String) {
+
+    func dismissModals(upToId: String, location: ModalLocation = .currentRouter) {
         printError()
     }
-    
-    func dismissModals(count: Int) {
+
+    func dismissModals(count: Int, location: ModalLocation = .currentRouter) {
         printError()
     }
-    
-    func dismissAllModals() {
+
+    func dismissAllModals(location: ModalLocation = .currentRouter) {
         printError()
     }
     

--- a/Sources/SwiftfulRouting/Core/RouterProtocol/RouterProtocol.swift
+++ b/Sources/SwiftfulRouting/Core/RouterProtocol/RouterProtocol.swift
@@ -39,11 +39,11 @@ protocol Router: Sendable {
     @MainActor func dismissAllAlerts()
 
     @MainActor func showModal(modal: AnyModal)
-    @MainActor func dismissModal()
-    @MainActor func dismissModal(id: String)
-    @MainActor func dismissModals(upToId: String)
-    @MainActor func dismissModals(count: Int)
-    @MainActor func dismissAllModals()
+    @MainActor func dismissModal(location: ModalLocation)
+    @MainActor func dismissModal(id: String, location: ModalLocation)
+    @MainActor func dismissModals(upToId: String, location: ModalLocation)
+    @MainActor func dismissModals(count: Int, location: ModalLocation)
+    @MainActor func dismissAllModals(location: ModalLocation)
     
     @MainActor func showTransition(transition: AnyTransitionDestination)
     @MainActor func showTransitions(transitions: [AnyTransitionDestination])

--- a/Sources/SwiftfulRouting/Core/RouterViews/RootRouterViewModelKey.swift
+++ b/Sources/SwiftfulRouting/Core/RouterViews/RootRouterViewModelKey.swift
@@ -1,0 +1,21 @@
+//
+//  RootRouterViewModelKey.swift
+//  SwiftfulRouting
+//
+//  Created by Nick Sarno on 3/21/26.
+//
+import SwiftUI
+
+/// Environment key that carries a reference to the topmost RouterViewModel in the hierarchy.
+/// Unlike @EnvironmentObject, this custom key is not shadowed when nested RouterViews
+/// inject their own RouterViewModel — it always points to the original root.
+struct RootRouterViewModelKey: EnvironmentKey {
+    static let defaultValue: RouterViewModel? = nil
+}
+
+extension EnvironmentValues {
+    var rootRouterViewModel: RouterViewModel? {
+        get { self[RootRouterViewModelKey.self] }
+        set { self[RootRouterViewModelKey.self] = newValue }
+    }
+}

--- a/Sources/SwiftfulRouting/Core/RouterViews/RouterView.swift
+++ b/Sources/SwiftfulRouting/Core/RouterViews/RouterView.swift
@@ -84,13 +84,18 @@ public struct RouterView<Content: View>: View {
 }
 
 struct RouterViewModelWrapper<Content: View>: View {
-    
+
     @StateObject private var viewModel = RouterViewModel()
+    @Environment(\.rootRouterViewModel) var inheritedRootViewModel
     @ViewBuilder var content: Content
 
     var body: some View {
         content
             .environmentObject(viewModel)
+            // Propagate the topmost RouterViewModel as a custom environment value.
+            // If no parent RouterView exists (inheritedRootViewModel is nil), we are the root — use self.
+            // If a parent RouterView exists, forward its root so all descendants can reach it.
+            .environment(\.rootRouterViewModel, inheritedRootViewModel ?? viewModel)
 
             #if DEBUG
             .onChange(of: viewModel.activeScreenStacks) { newValue in

--- a/Sources/SwiftfulRouting/Core/RouterViews/RouterViewInternal.swift
+++ b/Sources/SwiftfulRouting/Core/RouterViews/RouterViewInternal.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct RouterViewInternal<Content: View>: View, Router {
     
     @Environment(\.openURL) var openURL
+    @Environment(\.rootRouterViewModel) var rootRouterViewModel
 
     @EnvironmentObject var viewModel: RouterViewModel
     @EnvironmentObject var moduleViewModel: ModuleViewModel
@@ -266,27 +267,39 @@ struct RouterViewInternal<Content: View>: View, Router {
     }
     
     func showModal(modal: AnyModal) {
-        viewModel.showModal(routerId: routerId, modal: modal)
+        let vm = modal.location == .topRouter ? (rootRouterViewModel ?? viewModel) : viewModel
+        let targetRouterId = modal.location == .topRouter ? RouterViewModel.rootId : routerId
+        vm.showModal(routerId: targetRouterId, modal: modal)
     }
-    
-    func dismissModal() {
-        viewModel.dismissLastModal(onRouterId: routerId)
+
+    func dismissModal(location: ModalLocation = .currentRouter) {
+        let vm = location == .topRouter ? (rootRouterViewModel ?? viewModel) : viewModel
+        let targetRouterId = location == .topRouter ? RouterViewModel.rootId : routerId
+        vm.dismissLastModal(onRouterId: targetRouterId)
     }
-    
-    func dismissModal(id: String) {
-        viewModel.dismissModal(routerId: routerId, modalId: id)
+
+    func dismissModal(id: String, location: ModalLocation = .currentRouter) {
+        let vm = location == .topRouter ? (rootRouterViewModel ?? viewModel) : viewModel
+        let targetRouterId = location == .topRouter ? RouterViewModel.rootId : routerId
+        vm.dismissModal(routerId: targetRouterId, modalId: id)
     }
-    
-    func dismissModals(upToId: String) {
-        viewModel.dismissModals(routerId: routerId, to: upToId)
+
+    func dismissModals(upToId: String, location: ModalLocation = .currentRouter) {
+        let vm = location == .topRouter ? (rootRouterViewModel ?? viewModel) : viewModel
+        let targetRouterId = location == .topRouter ? RouterViewModel.rootId : routerId
+        vm.dismissModals(routerId: targetRouterId, to: upToId)
     }
-    
-    func dismissModals(count: Int) {
-        viewModel.dismissModals(routerId: routerId, count: count)
+
+    func dismissModals(count: Int, location: ModalLocation = .currentRouter) {
+        let vm = location == .topRouter ? (rootRouterViewModel ?? viewModel) : viewModel
+        let targetRouterId = location == .topRouter ? RouterViewModel.rootId : routerId
+        vm.dismissModals(routerId: targetRouterId, count: count)
     }
-    
-    func dismissAllModals() {
-        viewModel.dismissAllModals(routerId: routerId)
+
+    func dismissAllModals(location: ModalLocation = .currentRouter) {
+        let vm = location == .topRouter ? (rootRouterViewModel ?? viewModel) : viewModel
+        let targetRouterId = location == .topRouter ? RouterViewModel.rootId : routerId
+        vm.dismissAllModals(routerId: targetRouterId)
     }
     
     func showTransition(transition: AnyTransitionDestination) {

--- a/Sources/SwiftfulRouting/Core/RouterViews/RouterViewInternal.swift
+++ b/Sources/SwiftfulRouting/Core/RouterViews/RouterViewInternal.swift
@@ -267,38 +267,38 @@ struct RouterViewInternal<Content: View>: View, Router {
     }
     
     func showModal(modal: AnyModal) {
-        let vm = modal.location == .topRouter ? (rootRouterViewModel ?? viewModel) : viewModel
-        let targetRouterId = modal.location == .topRouter ? RouterViewModel.rootId : routerId
+        let vm = modal.location == .rootRouter ? (rootRouterViewModel ?? viewModel) : viewModel
+        let targetRouterId = modal.location == .rootRouter ? RouterViewModel.rootId : routerId
         vm.showModal(routerId: targetRouterId, modal: modal)
     }
 
     func dismissModal(location: ModalLocation = .currentRouter) {
-        let vm = location == .topRouter ? (rootRouterViewModel ?? viewModel) : viewModel
-        let targetRouterId = location == .topRouter ? RouterViewModel.rootId : routerId
+        let vm = location == .rootRouter ? (rootRouterViewModel ?? viewModel) : viewModel
+        let targetRouterId = location == .rootRouter ? RouterViewModel.rootId : routerId
         vm.dismissLastModal(onRouterId: targetRouterId)
     }
 
     func dismissModal(id: String, location: ModalLocation = .currentRouter) {
-        let vm = location == .topRouter ? (rootRouterViewModel ?? viewModel) : viewModel
-        let targetRouterId = location == .topRouter ? RouterViewModel.rootId : routerId
+        let vm = location == .rootRouter ? (rootRouterViewModel ?? viewModel) : viewModel
+        let targetRouterId = location == .rootRouter ? RouterViewModel.rootId : routerId
         vm.dismissModal(routerId: targetRouterId, modalId: id)
     }
 
     func dismissModals(upToId: String, location: ModalLocation = .currentRouter) {
-        let vm = location == .topRouter ? (rootRouterViewModel ?? viewModel) : viewModel
-        let targetRouterId = location == .topRouter ? RouterViewModel.rootId : routerId
+        let vm = location == .rootRouter ? (rootRouterViewModel ?? viewModel) : viewModel
+        let targetRouterId = location == .rootRouter ? RouterViewModel.rootId : routerId
         vm.dismissModals(routerId: targetRouterId, to: upToId)
     }
 
     func dismissModals(count: Int, location: ModalLocation = .currentRouter) {
-        let vm = location == .topRouter ? (rootRouterViewModel ?? viewModel) : viewModel
-        let targetRouterId = location == .topRouter ? RouterViewModel.rootId : routerId
+        let vm = location == .rootRouter ? (rootRouterViewModel ?? viewModel) : viewModel
+        let targetRouterId = location == .rootRouter ? RouterViewModel.rootId : routerId
         vm.dismissModals(routerId: targetRouterId, count: count)
     }
 
     func dismissAllModals(location: ModalLocation = .currentRouter) {
-        let vm = location == .topRouter ? (rootRouterViewModel ?? viewModel) : viewModel
-        let targetRouterId = location == .topRouter ? RouterViewModel.rootId : routerId
+        let vm = location == .rootRouter ? (rootRouterViewModel ?? viewModel) : viewModel
+        let targetRouterId = location == .rootRouter ? RouterViewModel.rootId : routerId
         vm.dismissAllModals(routerId: targetRouterId)
     }
     

--- a/Sources/SwiftfulRouting/Core/RouterViews/RouterViewModel.swift
+++ b/Sources/SwiftfulRouting/Core/RouterViews/RouterViewModel.swift
@@ -806,12 +806,7 @@ extension RouterViewModel {
     
     // Show modal on routerId
     func showModal(routerId: String, modal: AnyModal) {
-        // Every routerId needs an array if it doesn't have one already
-        if allModals[routerId] == nil {
-            allModals[routerId] = []
-        }
-        
-        allModals[routerId]!.append(modal)
+        allModals[routerId, default: []].append(modal)
         logger.trackEvent(event: Event.modalShow(modal: modal))
     }
     

--- a/Sources/SwiftfulRouting/Models/Modals/AnyModal.swift
+++ b/Sources/SwiftfulRouting/Models/Modals/AnyModal.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 public struct AnyModal: Identifiable, Equatable {
     public private(set) var id: String
+    public private(set) var location: ModalLocation
     public private(set) var transition: AnyTransition
     public private(set) var animation: Animation
     public private(set) var alignment: Alignment
@@ -19,10 +20,11 @@ public struct AnyModal: Identifiable, Equatable {
     public private(set) var destination: AnyView
     public private(set) var onDismiss: (() -> Void)?
     public private(set) var isRemoved: Bool = false
-    
+
     /// Show a modal.
     /// - Parameters:
     ///   - id: Identifier for modal.
+    ///   - location: Which router to display modal on. Use .topRouter to show on the root RouterView, above all nested routers (e.g. above a tab bar).
     ///   - transition: Transition to show and hide modal.
     ///   - animation: Animation to show and hide modal.
     ///   - alignment: Alignment within the screen.
@@ -34,6 +36,7 @@ public struct AnyModal: Identifiable, Equatable {
     ///   - destination: The modal View.
     public init<T:View>(
         id: String = UUID().uuidString,
+        location: ModalLocation = .currentRouter,
         transition: AnyTransition = .identity,
         animation: Animation = .smooth,
         alignment: Alignment = .center,
@@ -45,6 +48,7 @@ public struct AnyModal: Identifiable, Equatable {
         onDismiss: (() -> Void)? = nil
     ) {
         self.id = id
+        self.location = location
         self.transition = transition
         self.animation = animation
         self.alignment = alignment
@@ -85,6 +89,7 @@ public struct AnyModal: Identifiable, Equatable {
     public var eventParameters: [String: Any] {
         [
             "modal_id": id,
+            "modal_location": location.rawValue,
             "modal_is_removed": isRemoved,
             "modal_dismiss_bg_tap": dismissOnBackgroundTap,
             "modal_has_background_color": backgroundColor != nil,

--- a/Sources/SwiftfulRouting/Models/Modals/AnyModal.swift
+++ b/Sources/SwiftfulRouting/Models/Modals/AnyModal.swift
@@ -24,7 +24,7 @@ public struct AnyModal: Identifiable, Equatable {
     /// Show a modal.
     /// - Parameters:
     ///   - id: Identifier for modal.
-    ///   - location: Which router to display modal on. Use .topRouter to show on the root RouterView, above all nested routers (e.g. above a tab bar).
+    ///   - location: Which router to display modal on. Use .rootRouter to show on the root RouterView, above all nested routers (e.g. above a tab bar).
     ///   - transition: Transition to show and hide modal.
     ///   - animation: Animation to show and hide modal.
     ///   - alignment: Alignment within the screen.

--- a/Sources/SwiftfulRouting/Models/Modals/ModalLocation.swift
+++ b/Sources/SwiftfulRouting/Models/Modals/ModalLocation.swift
@@ -1,0 +1,11 @@
+//
+//  ModalLocation.swift
+//  SwiftfulRouting
+//
+//  Created by Nick Sarno on 3/21/26.
+//
+import Foundation
+
+public enum ModalLocation: String {
+    case currentRouter, topRouter
+}

--- a/Sources/SwiftfulRouting/Models/Modals/ModalLocation.swift
+++ b/Sources/SwiftfulRouting/Models/Modals/ModalLocation.swift
@@ -7,5 +7,5 @@
 import Foundation
 
 public enum ModalLocation: String {
-    case currentRouter, topRouter
+    case currentRouter, rootRouter
 }


### PR DESCRIPTION
The root RouterViewModel is propagated through the SwiftUI environment
via a custom EnvironmentKey (RootRouterViewModelKey). Unlike @EnvironmentObject,
this key is not shadowed when nested RouterViews inject their own VM — so it
always points to the outermost RouterView's RouterViewModel.

RouterViewInternal reads this key and, when location == .topRouter, switches
to the root VM and targets RouterViewModel.rootId ("root"), ensuring the modal
renders above all nested routers including tab bars.

Changes:
- Add ModalLocation enum (.currentRouter, .topRouter)
- Add RootRouterViewModelKey environment key + EnvironmentValues extension
- RouterViewModelWrapper propagates root VM via environment
- RouterViewInternal reads root VM and uses it for all modal ops on .topRouter
- Add location property to AnyModal (default .currentRouter)
- All showModal and dismissModal variants accept location parameter
- Fix existing force unwrap in RouterViewModel.showModal
- Update RouterProtocol, AnyRouter, MockRouter signatures
- Update README and Claude docs

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
