### PR TITLE
Adds root router access via environment

### DIFF
--- a/.claude/swiftful-routing-rules.md
+++ b/.claude/swiftful-routing-rules.md
@@ -320,6 +320,25 @@ router.dismissModals(upToId: "modal_id")        // dismiss down to specific moda
 router.dismissAllModals()                       // dismiss all modals
 ```
 
+### getRootRouter
+
+`router.getRootRouter()` returns the outermost `RouterView`'s router. **Only needed when `RouterView`s are nested** (e.g. a root `RouterView` wrapping a `TabView`, each tab also having its own `RouterView`). In that case, a modal shown on a child router renders behind the tab bar. Use `getRootRouter()` to show it on the root instead.
+
+**Default to using `router` directly.** Only reach for `getRootRouter()` when the user reports the modal appears behind a tab bar or other persistent UI layer.
+
+```swift
+// Default — show modal on the current router
+router.showModal { MyModal() }
+
+// Nested RouterView setup — show modal above the tab bar
+let rootRouter = router.getRootRouter()
+rootRouter.showModal(transition: .move(edge: .bottom), alignment: .bottom) {
+    MyModal(router: rootRouter)  // pass rootRouter so the modal can dismiss itself
+}
+```
+
+The returned router is a fully functional `AnyRouter` — all show/dismiss methods work normally on it.
+
 ## Transitions (showTransition)
 
 Replaces the current screen content with a new view using a SwiftUI transition. This is NOT a segue — it swaps what's displayed. Use only when explicitly asked.

--- a/README.md
+++ b/README.md
@@ -666,6 +666,19 @@ Dismiss all modals.
 router.dismissAllModals()
 ```
 
+#### Nested RouterViews — showing a modal above a tab bar
+
+When `RouterView`s are nested (e.g. a root `RouterView` wrapping a `TabView`, each tab also having its own `RouterView`), a modal shown on a child router will render behind the tab bar. Use `getRootRouter()` to target the outermost `RouterView` instead.
+
+```swift
+let rootRouter = router.getRootRouter()
+rootRouter.showModal(transition: .move(edge: .bottom), alignment: .bottom) {
+    MyModal(router: rootRouter)
+}
+```
+
+Pass `rootRouter` into the destination so the modal can dismiss itself correctly. If your app does not nest `RouterView`s, `getRootRouter()` simply returns the current router.
+
 Additional convenience methods:
 
 ```swift

--- a/Sources/SwiftfulRouting/Core/RouterProtocol/AnyRouter.swift
+++ b/Sources/SwiftfulRouting/Core/RouterProtocol/AnyRouter.swift
@@ -420,7 +420,13 @@ public struct AnyRouter: Sendable, Router {
     @MainActor public func dismissAllModals() {
         object.dismissAllModals()
     }
-    
+
+    /// Returns the root AnyRouter — the outermost RouterView in the hierarchy.
+    /// Use this when you need to show a modal above all nested routers (e.g. above a tab bar).
+    @MainActor public func getRootRouter() -> AnyRouter {
+        object.getRootRouter()
+    }
+
     /// Transition current screen.
     /// - Parameters:
     ///   - transition: Transition animation option.

--- a/Sources/SwiftfulRouting/Core/RouterProtocol/MockRouter.swift
+++ b/Sources/SwiftfulRouting/Core/RouterProtocol/MockRouter.swift
@@ -143,7 +143,11 @@ struct MockRouter: Router {
     func dismissAllModals() {
         printError()
     }
-    
+
+    func getRootRouter() -> AnyRouter {
+        AnyRouter(id: "mock", rootRouterId: "mock", object: self)
+    }
+
     func showTransition(transition: AnyTransitionDestination) {
         printError()
     }

--- a/Sources/SwiftfulRouting/Core/RouterProtocol/RouterProtocol.swift
+++ b/Sources/SwiftfulRouting/Core/RouterProtocol/RouterProtocol.swift
@@ -67,4 +67,6 @@ protocol Router: Sendable {
     @MainActor func dismissAllModules()
 
     @MainActor func showSafari(_ url: @escaping () -> URL)
+
+    @MainActor func getRootRouter() -> AnyRouter
 }

--- a/Sources/SwiftfulRouting/Core/RouterViews/RootAnyRouterKey.swift
+++ b/Sources/SwiftfulRouting/Core/RouterViews/RootAnyRouterKey.swift
@@ -1,0 +1,20 @@
+//
+//  RootAnyRouterKey.swift
+//  SwiftfulRouting
+//
+//  Created by Nick Sarno on 3/23/26.
+//
+import SwiftUI
+
+/// Environment key that carries a reference to the root AnyRouter in the hierarchy.
+/// Unlike \.router (which is shadowed by each nested RouterView), this key always points to the outermost RouterView's router.
+struct RootAnyRouterKey: EnvironmentKey {
+    static let defaultValue: AnyRouter? = nil
+}
+
+extension EnvironmentValues {
+    var rootRouter: AnyRouter? {
+        get { self[RootAnyRouterKey.self] }
+        set { self[RootAnyRouterKey.self] = newValue }
+    }
+}

--- a/Sources/SwiftfulRouting/Core/RouterViews/RouterViewInternal.swift
+++ b/Sources/SwiftfulRouting/Core/RouterViews/RouterViewInternal.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct RouterViewInternal<Content: View>: View, Router {
     
     @Environment(\.openURL) var openURL
+    @Environment(\.rootRouter) var inheritedRootRouter
 
     @EnvironmentObject var viewModel: RouterViewModel
     @EnvironmentObject var moduleViewModel: ModuleViewModel
@@ -115,6 +116,8 @@ struct RouterViewInternal<Content: View>: View, Router {
         
         // Add to environment for convenience
         .environment(\.router, currentRouter)
+        // Propagate the root AnyRouter. If no parent RouterView exists, we are the root — use self.
+        .environment(\.rootRouter, inheritedRootRouter ?? currentRouter)
     }
     
     private var parentDestination: AnyDestination? {
@@ -365,6 +368,10 @@ struct RouterViewInternal<Content: View>: View, Router {
         let url = url()
         openURL(url)
         logger.trackEvent(event: RouterViewModel.Event.showSafari(url: url))
+    }
+
+    func getRootRouter() -> AnyRouter {
+        inheritedRootRouter ?? currentRouter
     }
 }
 


### PR DESCRIPTION
Introduces the `getRootRouter()` method, enabling any router within the hierarchy to retrieve a reference to the outermost `AnyRouter`.

This functionality is implemented by:
- Propagating the root router through a new `EnvironmentKey` (`RootAnyRouterKey`).
- Modifying `RouterView` to pass down the `rootRouter` from its environment. If no parent `RouterView` exists, the current `RouterView` is identified and propagated as the root.

This change allows for actions such as presenting a modal above all nested routers, like a tab bar, by interacting directly with the application's top-level router.