### PR TITLE
Fix push navigation ignoring animates: false (#118)

### DIFF
--- a/Sources/SwiftfulRouting/Core/RouterViews/RouterViewInternal.swift
+++ b/Sources/SwiftfulRouting/Core/RouterViews/RouterViewInternal.swift
@@ -150,12 +150,15 @@ struct RouterViewInternal<Content: View>: View, Router {
             return subStack.screens.contains(where: { $0.id == routerId })
         }
         guard let index, newStack.indices.contains(index + 1) else {
-            stableScreenStack.setNewValueIfNeeded(newValue: [])
+            stableScreenStack.setNewValueIfNeeded(newValue: [], animates: false)
             return
         }
         
         let activeStack = newStack[index + 1].screens
-        stableScreenStack.setNewValueIfNeeded(newValue: activeStack)
+        // Forward the animates flag from the last destination so the NavigationStack path
+        // update stays within the same withTransaction context that RouterViewModel set.
+        let animates = activeStack.last?.animates ?? true
+        stableScreenStack.setNewValueIfNeeded(newValue: activeStack, animates: animates)
     }
             
     var activeScreens: [AnyDestinationStack] {

--- a/Sources/SwiftfulRouting/Core/RouterViews/RouterViewInternal.swift
+++ b/Sources/SwiftfulRouting/Core/RouterViews/RouterViewInternal.swift
@@ -149,15 +149,19 @@ struct RouterViewInternal<Content: View>: View, Router {
         let index = newStack.firstIndex { subStack in
             return subStack.screens.contains(where: { $0.id == routerId })
         }
+        // This handler runs on SwiftUI's schedule, outside the withTransaction context
+        // that RouterViewModel.triggerAction set for this change (onChange actions are
+        // always deferred, and even .onReceive delivery is not reliably synchronous).
+        // The action's animates flag therefore travels via viewModel.lastActionAnimates
+        // and is re-applied as a transaction inside setNewValueIfNeeded.
+        let animates = viewModel.lastActionAnimates
+
         guard let index, newStack.indices.contains(index + 1) else {
-            stableScreenStack.setNewValueIfNeeded(newValue: [], animates: false)
+            stableScreenStack.setNewValueIfNeeded(newValue: [], animates: animates)
             return
         }
-        
+
         let activeStack = newStack[index + 1].screens
-        // Forward the animates flag from the last destination so the NavigationStack path
-        // update stays within the same withTransaction context that RouterViewModel set.
-        let animates = activeStack.last?.animates ?? true
         stableScreenStack.setNewValueIfNeeded(newValue: activeStack, animates: animates)
     }
             

--- a/Sources/SwiftfulRouting/Core/RouterViews/RouterViewModel.swift
+++ b/Sources/SwiftfulRouting/Core/RouterViews/RouterViewModel.swift
@@ -38,6 +38,13 @@ final class RouterViewModel: ObservableObject {
     
     // Available transitions in queue, accessible via .showNextTransition()
     @Published private(set) var availableTransitionQueue: [String: [AnyTransitionDestination]] = [:]
+
+    // The animates value of the most recent activeScreenStacks action.
+    // The handlers that forward activeScreenStacks changes into each NavigationStack's
+    // path run on SwiftUI's schedule, outside the withTransaction context set in
+    // triggerAction, so the flag must travel with the data and be re-applied at the
+    // point the path is mutated (see StableAnyDestinationArray.setNewValueIfNeeded).
+    private(set) var lastActionAnimates: Bool = true
         
     // Only called once onFirstAppear in the root router.
     // This replaces starting activeScreenStacks value.
@@ -393,6 +400,7 @@ extension RouterViewModel {
     
     // Utility functino to trigger action with or without SwiftUI animation
     private func triggerAction(withAnimation: Bool, action: @escaping () -> Void) {
+        lastActionAnimates = withAnimation
         if withAnimation {
             action()
         } else {

--- a/Sources/SwiftfulRouting/Models/Screens/StableAnyDestinationArray.swift
+++ b/Sources/SwiftfulRouting/Models/Screens/StableAnyDestinationArray.swift
@@ -13,9 +13,16 @@ final class StableAnyDestinationArray: ObservableObject, Equatable {
         self.destinations = destinations
     }
     
-    func setNewValueIfNeeded(newValue: [AnyDestination]) {
-        if destinations != newValue {
+    func setNewValueIfNeeded(newValue: [AnyDestination], animates: Bool = true) {
+        guard destinations != newValue else { return }
+        if animates {
             destinations = newValue
+        } else {
+            var transaction = Transaction(animation: .none)
+            transaction.disablesAnimations = true
+            withTransaction(transaction) {
+                destinations = newValue
+            }
         }
     }
 

--- a/Sources/SwiftfulRouting/Models/Screens/StableAnyDestinationArray.swift
+++ b/Sources/SwiftfulRouting/Models/Screens/StableAnyDestinationArray.swift
@@ -13,7 +13,7 @@ final class StableAnyDestinationArray: ObservableObject, Equatable {
         self.destinations = destinations
     }
     
-    func setNewValueIfNeeded(newValue: [AnyDestination], animates: Bool = true) {
+    func setNewValueIfNeeded(newValue: [AnyDestination], animates: Bool) {
         guard destinations != newValue else { return }
         if animates {
             destinations = newValue


### PR DESCRIPTION
When RouterViewModel.triggerAction(withAnimation: false) mutates activeScreenStacks, it correctly wraps the change in a SwiftUI Transaction with disablesAnimations = true.

However, RouterViewInternal.handleActiveScreenStackDidChange() then called stableScreenStack.setNewValueIfNeeded(newValue:) without forwarding that animation context. Because StableAnyDestinationArray publishes its @Published destinations property outside the original transaction, the NavigationStack always received the path update with animations re-enabled — causing push navigation to animate even when animates: false was specified.

Fix:
- StableAnyDestinationArray.setNewValueIfNeeded now accepts an animates parameter (default true). When animates is false it wraps the setter in a new Transaction(animation: .none) with disablesAnimations = true, preserving the intent end-to-end.
- handleActiveScreenStackDidChange reads the animates flag from the last destination in the new stack and forwards it to the setter.

Regression note: this was working in v6.1.0. The bug was introduced in v6.1.2 (PR #94) when StableAnyDestinationArray was added as an intermediary between RouterViewModel and the NavigationStack path.

Fixes: https://github.com/SwiftfulThinking/SwiftfulRouting/issues/118